### PR TITLE
Feat: 기록장 및 회복 기록 기능 구현

### DIFF
--- a/controllers/recordBookController.js
+++ b/controllers/recordBookController.js
@@ -1,0 +1,59 @@
+const recordBookService = require('../services/recordBookService');
+
+// 기록장 생성
+exports.createRecordBook = async (req, res) => {
+  try {
+    const user_id = req.user.user_id;
+    const { title, hospital_id, surgery_date, surgery_ids } = req.body;
+    const result = await recordBookService.createRecordBook({ user_id, title, hospital_id, surgery_date, surgery_ids });
+    res.status(201).json(result);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// 기록장 목록 조회
+exports.getRecordBooks = async (req, res) => {
+  try {
+    const user_id = req.user.user_id;
+    const { page = 1, limit = 10, sort } = req.query;
+    const result = await recordBookService.getRecordBooks({ user_id, page, limit, sort });
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// 기록장 상세 조회
+exports.getRecordBookDetail = async (req, res) => {
+  try {
+    const { recordBookId } = req.params;
+    const result = await recordBookService.getRecordBookDetail(recordBookId);
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// 기록장 수정
+exports.updateRecordBook = async (req, res) => {
+  try {
+    const { recordBookId } = req.params;
+    const { title } = req.body;
+    const result = await recordBookService.updateRecordBook(recordBookId, { title });
+    res.status(200).json(result);
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};
+
+// 기록장 삭제
+exports.deleteRecordBook = async (req, res) => {
+  try {
+    const { recordBookId } = req.params;
+    await recordBookService.deleteRecordBook(recordBookId);
+    res.status(204).send();
+  } catch (err) {
+    res.status(500).json({ message: err.message });
+  }
+};

--- a/controllers/recordEntryController.js
+++ b/controllers/recordEntryController.js
@@ -1,0 +1,53 @@
+const recordEntryService = require('../services/recordEntryService');
+
+exports.createRecordEntry = async (req, res) => {
+  try {
+    const recordBookId = req.params.recordBookId;
+    const result = await recordEntryService.createRecordEntry(recordBookId, req.body);
+    res.status(201).json(result);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.getRecordEntries = async (req, res) => {
+  try {
+    const recordBookId = req.params.recordBookId;
+    const query = req.query;
+    const result = await recordEntryService.getRecordEntries(recordBookId, query);
+    res.json(result);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.getRecordEntryDetail = async (req, res) => {
+  try {
+    const entryId = req.params.recordEntryId;
+    const entry = await recordEntryService.getRecordEntryDetail(entryId);
+    if (!entry) return res.status(404).json({ message: 'Not found' });
+    res.json(entry);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.updateRecordEntry = async (req, res) => {
+  try {
+    const entryId = req.params.recordEntryId;
+    const result = await recordEntryService.updateRecordEntry(entryId, req.body);
+    res.json(result);
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+};
+
+exports.deleteRecordEntry = async (req, res) => {
+  try {
+    const entryId = req.params.recordEntryId;
+    await recordEntryService.deleteRecordEntry(entryId);
+    res.status(204).send();
+  } catch (err) {
+    res.status(400).json({ message: err.message });
+  }
+};

--- a/middlewares/authMiddleware.js
+++ b/middlewares/authMiddleware.js
@@ -1,5 +1,5 @@
 const jwt = require('jsonwebtoken');
-const userModel = require('../models/schemas/user');
+const User = require('../models/schemas/user');
 
 const verifyToken = async (req, res, next) => {
     try {
@@ -13,7 +13,7 @@ const verifyToken = async (req, res, next) => {
         }
 
         const decoded = jwt.verify(token, process.env.JWT_SECRET);
-        const user = await userModel.findById(decoded.user_id);
+        const user = await User.findByPk(decoded.user_id);
 
         if (!user || user.state !== 'ACTIVE') {
             return res.stauts(401).json({

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,53 @@
       "devDependencies": {
         "nodemon": "^3.1.10",
         "prettier": "^3.5.3",
-        "sequelize-cli": "^6.6.3"
+        "sequelize-cli": "^6.6.3",
+        "swagger-jsdoc": "^6.2.8",
+        "swagger-ui-express": "^5.0.1"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.1.2.tgz",
+      "integrity": "sha512-r1w81DpR+KyRWd3f+rk6TNqMgedmAxZP5v5KWlXQWlgMUUtyEJch0DKEci1SorPMiSeM8XPl7MZ3miJ60JIpQg==",
+      "dev": true,
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
+    "node_modules/@apidevtools/openapi-schemas": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
+      "integrity": "sha512-Zc1AlqrJlX3SlpupFGpiLi2EbteyP7fXmUOGup6/DnkRgjP9bgMM/ag+n91rsv0U1Gpz0H3VILA/o3bW7Ua6BQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@apidevtools/swagger-methods": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-methods/-/swagger-methods-3.0.2.tgz",
+      "integrity": "sha512-QAkD5kK2b1WfjDS/UQn/qQkbwF31uqRjPTrsCs5ZG9BQGAkjwvqGFjjPqAuzac/IYzpPtRzjCP1WrTuAIjMrXg==",
+      "dev": true
+    },
+    "node_modules/@apidevtools/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-sNiLY51vZOmSPFZA5TF35KZ2HbgYklQnTSDnkghamzLb3EkNtcQnrBQEj5AOCxHpTtXpqMCRM1CrmV2rG6nw4g==",
+      "dev": true,
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^9.0.6",
+        "@apidevtools/openapi-schemas": "^2.0.4",
+        "@apidevtools/swagger-methods": "^3.0.2",
+        "@jsdevtools/ono": "^7.1.3",
+        "call-me-maybe": "^1.0.1",
+        "z-schema": "^5.0.1"
+      },
+      "peerDependencies": {
+        "openapi-types": ">=7"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -40,6 +86,12 @@
         "node": ">=12"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "dev": true
+    },
     "node_modules/@one-ini/wasm": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
@@ -56,6 +108,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "dev": true,
+      "hasInstallScript": true
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -63,6 +122,12 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -139,6 +204,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -274,6 +345,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/call-me-maybe": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
+      "integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
+      "dev": true
     },
     "node_modules/chokidar": {
       "version": "3.6.0",
@@ -519,6 +596,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
@@ -664,6 +753,15 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -787,6 +885,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1006,6 +1110,17 @@
         "node >= 0.4.0"
       ]
     },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -1152,6 +1267,18 @@
         "node": ">=14"
       }
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -1209,6 +1336,13 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+      "deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+      "dev": true
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1218,6 +1352,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "dev": true
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
@@ -1238,6 +1379,12 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+    },
+    "node_modules/lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==",
+      "dev": true
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
@@ -1508,6 +1655,13 @@
         "wrappy": "1"
       }
     },
+    "node_modules/openapi-types": {
+      "version": "12.1.3",
+      "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
+      "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -1520,6 +1674,15 @@
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -2146,6 +2309,92 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-jsdoc": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-6.2.8.tgz",
+      "integrity": "sha512-VPvil1+JRpmJ55CgAtn8DIcpBs0bL5L3q5bVQvF4tAW/k/9JYSj7dCpaYCAv5rufe0vcCbBRQXGvzpkWjvLklQ==",
+      "dev": true,
+      "dependencies": {
+        "commander": "6.2.0",
+        "doctrine": "3.0.0",
+        "glob": "7.1.6",
+        "lodash.mergewith": "^4.6.2",
+        "swagger-parser": "^10.0.3",
+        "yaml": "2.0.0-1"
+      },
+      "bin": {
+        "swagger-jsdoc": "bin/swagger-jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/commander": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+      "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/swagger-jsdoc/node_modules/glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/swagger-parser": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-10.0.3.tgz",
+      "integrity": "sha512-nF7oMeL4KypldrQhac8RyHerJeGPD1p2xDh900GPvc+Nk7nWP6jX2FcC7WmkinMoAmoO774+AFXcWsW8gMWEIg==",
+      "dev": true,
+      "dependencies": {
+        "@apidevtools/swagger-parser": "10.0.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.26.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.26.0.tgz",
+      "integrity": "sha512-U8m1LruHrk33gIIT5qDKhXMygT4FonRGBE92zMbxP4i9ULolPlKISy5Pd3RCES8pWdbGzXhvm/Q6jdA/HsrClg==",
+      "dev": true,
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "dev": true,
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2385,6 +2634,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/yaml": {
+      "version": "2.0.0-1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.0.0-1.tgz",
+      "integrity": "sha512-W7h5dEhywMKenDJh2iX/LABkbFnBxasD27oyXWDS/feDsxiw0dD5ncXdYXgkvAsXIY2MpW/ZKkr9IU30DBdMNQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -2451,6 +2709,36 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/z-schema": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.5.tgz",
+      "integrity": "sha512-D7eujBWkLa3p2sIpJA0d1pr7es+a7m0vFAnZLlCEKq/Ij2k0MLi9Br2UPxoxdYystm5K1yeBGzub0FlYUEWj2Q==",
+      "dev": true,
+      "dependencies": {
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.5.0",
+        "validator": "^13.7.0"
+      },
+      "bin": {
+        "z-schema": "bin/z-schema"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "commander": "^9.4.1"
+      }
+    },
+    "node_modules/z-schema/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
   "devDependencies": {
     "nodemon": "^3.1.10",
     "prettier": "^3.5.3",
-    "sequelize-cli": "^6.6.3"
+    "sequelize-cli": "^6.6.3",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^5.0.1"
   }
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,15 +1,7 @@
 const express = require('express');
 const router = express.Router();
 
-router.use('/auth', require('./auth.routes'));
-router.use('/users', require('./user.routes'));
-router.use('/hospitals', require('./hospital.routes'));
-router.use('/surgery', require('./surgery.routes'));
-router.use('/record-books', require('./record-book.routes'));
-router.use('/consulations', require('./consulation.routes'));
-router.use('/payments', require('./payment.routes'));
-router.use('/articles', require('./article.routes'));
-router.use('/notifications', require('./notification.routes'));
-router.use('/admin', require('./admin.routes'));
+router.use('/record-books', require('./recordBooks'));
+router.use('/record-entries', require('./recordEntries'));
 
 module.exports = router;

--- a/routes/recordBooks.js
+++ b/routes/recordBooks.js
@@ -1,0 +1,244 @@
+const express = require('express');
+const router = express.Router();
+const recordBookController = require('../controllers/recordBookController');
+const { verifyToken } = require('../middlewares/authMiddleware');
+
+/**
+ * @swagger
+ * tags:
+ *   name: RecordBook
+ *   description: 기록장 관리 API
+ */
+
+/**
+ * @swagger
+ * /record-books:
+ *   post:
+ *     summary: 기록장 생성
+ *     tags: [RecordBook]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [title, hospital_id, surgery_date, surgery_ids]
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 example: 2025년 코성형 기록
+ *               hospital_id:
+ *                 type: integer
+ *                 example: 1
+ *               surgery_date:
+ *                 type: string
+ *                 format: date
+ *                 example: 2025-07-06
+ *               surgery_ids:
+ *                 type: array
+ *                 items:
+ *                   type: integer
+ *                 example: [3, 4]
+ *     responses:
+ *       201:
+ *         description: 기록장 생성 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 record_book_id:
+ *                   type: integer
+ *                   example: 10
+ *                 title:
+ *                   type: string
+ *                   example: 2025년 코성형 기록
+ */
+router.post('/', recordBookController.createRecordBook);
+
+/**
+ * @swagger
+ * /record-books:
+ *   get:
+ *     summary: 기록장 목록 조회
+ *     tags: [RecordBook]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: page
+ *         in: query
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *       - name: limit
+ *         in: query
+ *         schema:
+ *           type: integer
+ *           default: 10
+ *       - name: sort
+ *         in: query
+ *         schema:
+ *           type: string
+ *           default: created_at
+ *     responses:
+ *       200:
+ *         description: 기록장 목록 반환
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 record_books:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       record_book_id:
+ *                         type: integer
+ *                         example: 1
+ *                       title:
+ *                         type: string
+ *                         example: 2025년 코성형 기록
+ *                       hospital_name:
+ *                         type: string
+ *                         example: 서울중앙병원
+ *                       surgery_date:
+ *                         type: string
+ *                         format: date
+ *                         example: 2025-07-06
+ *                       created_at:
+ *                         type: string
+ *                         format: date-time
+ *                         example: 2025-07-06T12:00:00.000Z
+ *                 pagination:
+ *                   type: object
+ *                   properties:
+ *                     page:
+ *                       type: integer
+ *                       example: 1
+ *                     limit:
+ *                       type: integer
+ *                       example: 10
+ *                     total:
+ *                       type: integer
+ *                       example: 2
+ */
+router.get('/', verifyToken, recordBookController.getRecordBooks);
+
+/**
+ * @swagger
+ * /record-books/{recordBookId}:
+ *   get:
+ *     summary: 기록장 상세 조회
+ *     tags: [RecordBook]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: recordBookId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: 기록장 상세 정보 반환
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 record_book_id:
+ *                   type: integer
+ *                   example: 1
+ *                 title:
+ *                   type: string
+ *                   example: 2025년 코성형 기록
+ *                 hospital_name:
+ *                   type: string
+ *                   example: 서울중앙병원
+ *                 surgery_date:
+ *                   type: string
+ *                   format: date
+ *                   example: 2025-07-06
+ *                 surgeries:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       surgery_id:
+ *                         type: integer
+ *                         example: 3
+ *                       detail:
+ *                         type: string
+ *                         example: 코끝 성형
+ */
+router.get('/:recordBookId', verifyToken, recordBookController.getRecordBookDetail);
+
+/**
+ * @swagger
+ * /record-books/{recordBookId}:
+ *   patch:
+ *     summary: 기록장 수정
+ *     tags: [RecordBook]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: recordBookId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               title:
+ *                 type: string
+ *                 example: 2025년 코성형 기록 (수정)
+ *     responses:
+ *       200:
+ *         description: 기록장 수정 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 record_book_id:
+ *                   type: integer
+ *                   example: 1
+ *                 title:
+ *                   type: string
+ *                   example: 2025년 코성형 기록 (수정)
+ *                 updated_at:
+ *                   type: string
+ *                   format: date-time
+ *                   example: 2025-07-06T13:00:00.000Z
+ */
+router.patch('/:recordBookId', verifyToken, recordBookController.updateRecordBook);
+
+/**
+ * @swagger
+ * /record-books/{recordBookId}:
+ *   delete:
+ *     summary: 기록장 삭제
+ *     tags: [RecordBook]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: recordBookId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       204:
+ *         description: 기록장 삭제 성공
+ */
+router.delete('/:recordBookId', verifyToken, recordBookController.deleteRecordBook);
+
+module.exports = router;

--- a/routes/recordBooks.js
+++ b/routes/recordBooks.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const recordBookController = require('../controllers/recordBookController');
+const recordEntryController = require('../controllers/recordEntryController');
 const { verifyToken } = require('../middlewares/authMiddleware');
 
 /**
@@ -240,5 +241,147 @@ router.patch('/:recordBookId', verifyToken, recordBookController.updateRecordBoo
  *         description: 기록장 삭제 성공
  */
 router.delete('/:recordBookId', verifyToken, recordBookController.deleteRecordBook);
+
+/**
+ * @swagger
+ * /record-books/{recordBookId}/entries:
+ *   post:
+ *     summary: 회복 기록 작성
+ *     tags: [RecordEntry]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: recordBookId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [date]
+ *             properties:
+ *               date:
+ *                 type: string
+ *                 format: date
+ *                 example: 2025-07-09
+ *               symptom:
+ *                 type: string
+ *                 example: 두통과 미열이 있었음.
+ *               diary:
+ *                 type: string
+ *                 example: 오늘은 컨디션이 조금 나아졌다. 충분히 휴식함.
+ *               images:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                   example: https://example.com/images/recovery1.jpg
+ *     responses:
+ *       201:
+ *         description: 회복 기록 생성 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 entry_id:
+ *                   type: integer
+ *                   example: 1
+ *                 date:
+ *                   type: string
+ *                   format: date
+ *                   example: 2025-07-09
+ */
+router.post('/:recordBookId/entries', verifyToken, recordEntryController.createRecordEntry);
+
+/**
+ * @swagger
+ * /record-books/{recordBookId}/entries:
+ *   get:
+ *     summary: 회복 기록 목록 조회
+ *     tags: [RecordEntry]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: recordBookId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *       - name: date
+ *         in: query
+ *         schema:
+ *           type: string
+ *           format: date
+ *       - name: page
+ *         in: query
+ *         schema:
+ *           type: integer
+ *           default: 1
+ *       - name: limit
+ *         in: query
+ *         schema:
+ *           type: integer
+ *           default: 10
+ *       - name: sort
+ *         in: query
+ *         schema:
+ *           type: string
+ *           enum: [asc, desc]
+ *           default: desc
+ *     responses:
+ *       200:
+ *         description: 회복 기록 목록 반환
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 entries:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       entry_id:
+ *                         type: integer
+ *                         example: 1
+ *                       date:
+ *                         type: string
+ *                         format: date
+ *                         example: 2025-07-09
+ *                       symptom:
+ *                         type: string
+ *                         example: 두통과 미열이 있었음.
+ *                       diary:
+ *                         type: string
+ *                         example: 오늘은 컨디션이 조금 나아졌다. 충분히 휴식함.
+ *                       images:
+ *                         type: array
+ *                         items:
+ *                           type: object
+ *                           properties:
+ *                             image_id:
+ *                               type: integer
+ *                               example: 1
+ *                             image_url:
+ *                               type: string
+ *                               example: https://example.com/images/recovery1.jpg
+ *                 pagination:
+ *                   type: object
+ *                   properties:
+ *                     total:
+ *                       type: integer
+ *                       example: 2
+ *                     page:
+ *                       type: integer
+ *                       example: 1
+ *                     limit:
+ *                       type: integer
+ *                       example: 2
+ */
+router.get('/:recordBookId/entries', verifyToken, recordEntryController.getRecordEntries);
 
 module.exports = router;

--- a/routes/recordEntries.js
+++ b/routes/recordEntries.js
@@ -1,0 +1,139 @@
+const express = require('express');
+const router = express.Router();
+const recordEntryController = require('../controllers/recordEntryController');
+const { verifyToken } = require('../middlewares/authMiddleware');
+
+/**
+ * @swagger
+ * tags:
+ *   name: RecordEntry
+ *   description: 회복 기록 관리 API
+ */
+
+/**
+ * @swagger
+ * /record-entries/{recordEntryId}:
+ *   get:
+ *     summary: 회복 기록 상세 조회
+ *     tags: [RecordEntry]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: recordEntryId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       200:
+ *         description: 회복 기록 상세 정보 반환
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 entry_id:
+ *                   type: integer
+ *                   example: 1
+ *                 record_book_id:
+ *                   type: integer
+ *                   example: 1
+ *                 date:
+ *                   type: string
+ *                   format: date
+ *                   example: 2025-07-09
+ *                 symptom:
+ *                   type: string
+ *                   example: 두통과 미열이 있었음.
+ *                 diary:
+ *                   type: string
+ *                   example: 오늘은 컨디션이 조금 나아졌다. 충분히 휴식함.
+ *                 images:
+ *                   type: array
+ *                   items:
+ *                     type: object
+ *                     properties:
+ *                       image_id:
+ *                         type: integer
+ *                         example: 1
+ *                       image_url:
+ *                         type: string
+ *                         example: https://example.com/images/recovery1.jpg
+ *                 created_at:
+ *                   type: string
+ *                   format: date-time
+ *                   example: 2025-07-09T10:00:00.000Z
+ */
+router.get('/:recordEntryId', verifyToken, recordEntryController.getRecordEntryDetail);
+
+/**
+ * @swagger
+ * /record-entries/{recordEntryId}:
+ *   patch:
+ *     summary: 회복 기록 수정
+ *     tags: [RecordEntry]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: recordEntryId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               symptom:
+ *                 type: string
+ *                 example: 두통이 거의 사라짐.
+ *               diary:
+ *                 type: string
+ *                 example: 오늘은 산책도 할 수 있었다.
+ *               images:
+ *                 type: array
+ *                 items:
+ *                   type: string
+ *                   example: https://example.com/images/recovery3.jpg
+ *     responses:
+ *       200:
+ *         description: 회복 기록 수정 성공
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 entry_id:
+ *                   type: integer
+ *                   example: 1
+ *                 updated_at:
+ *                   type: string
+ *                   format: date-time
+ *                   example: 2025-07-10T09:30:00.000Z
+ */
+router.patch('/:recordEntryId', verifyToken, recordEntryController.updateRecordEntry);
+
+/**
+ * @swagger
+ * /record-entries/{recordEntryId}:
+ *   delete:
+ *     summary: 회복 기록 삭제
+ *     tags: [RecordEntry]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - name: recordEntryId
+ *         in: path
+ *         required: true
+ *         schema:
+ *           type: integer
+ *     responses:
+ *       204:
+ *         description: 회복 기록 삭제 성공
+ */
+router.delete('/:recordEntryId', verifyToken, recordEntryController.deleteRecordEntry);
+
+module.exports = router;

--- a/server.js
+++ b/server.js
@@ -1,4 +1,7 @@
 const express = require('express');
+const swaggerUi = require('swagger-ui-express');
+const { specs } = require('./swagger/swagger');
+
 const cors = require('cors');
 require('dotenv').config();
 
@@ -9,6 +12,9 @@ const PORT = process.env.PORT;
 
 app.use(cors());
 app.use(express.json());
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(specs));
+
+app.use('/', require('./routes/index'));
 
 
 app.listen(PORT, () => {

--- a/services/recordBookService.js
+++ b/services/recordBookService.js
@@ -1,0 +1,106 @@
+const { RecordBook, RecordBookSurgery, Surgery, Hospital, User, sequelize } = require('../models');
+
+// 기록장 생성
+exports.createRecordBook = async ({ user_id, title, hospital_id, surgery_date, surgery_ids }) => {
+  const t = await sequelize.transaction();
+  try {
+    const newRecordBook = await RecordBook.create(
+      { user_id, title, hospital_id, surgery_date },
+      { transaction: t }
+    );
+
+    if (Array.isArray(surgery_ids) && surgery_ids.length > 0) {
+      const bulkData = surgery_ids.map(surgery_id => ({
+        record_book_id: newRecordBook.record_book_id,
+        surgery_id
+      }));
+      await RecordBookSurgery.bulkCreate(bulkData, { transaction: t });
+    }
+
+    await t.commit();
+    return {
+      record_book_id: newRecordBook.record_book_id,
+      title: newRecordBook.title
+    };
+  } catch (err) {
+    await t.rollback();
+    throw err;
+  }
+};
+
+// 기록장 목록 조회
+exports.getRecordBooks = async ({ user_id, page = 1, limit = 10, sort = 'created_at' }) => {
+  const offset = (page - 1) * limit;
+  const { count, rows } = await RecordBook.findAndCountAll({
+    where: { user_id },
+    include: [
+      { model: Hospital, as: 'hospital', attributes: ['name'] }
+    ],
+    order: [[sort, 'DESC']],
+    limit,
+    offset
+  });
+
+  return {
+    record_books: rows.map(rb => ({
+      record_book_id: rb.record_book_id,
+      title: rb.title,
+      hospital_name: rb.hospital ? rb.hospital.name : null,
+      surgery_date: rb.surgery_date,
+      created_at: rb.created_at
+    })),
+    pagination: { page: Number(page), limit: Number(limit), total: count }
+  };
+};
+
+// 기록장 상세 조회
+exports.getRecordBookDetail = async (recordBookId) => {
+  const recordBook = await RecordBook.findByPk(recordBookId, {
+    include: [
+      { model: Hospital, as: 'hospital', attributes: ['name'] },
+      {
+        model: RecordBookSurgery,
+        as: 'record_book_surgeries',
+        include: [
+            {
+                model: Surgery, 
+                as: 'surgery',
+                attributes: ['surgery_id', 'detail'] 
+            }
+        ]
+      }
+    ]
+  });
+
+  if (!recordBook) throw new Error('기록장을 찾을 수 없습니다.');
+
+  return {
+    record_book_id: recordBook.record_book_id,
+    title: recordBook.title,
+    hospital_name: recordBook.hospital ? recordBook.hospital.name : null,
+    surgery_date: recordBook.surgery_date,
+    surgeries: recordBook.record_book_surgeries.map(rbs => ({
+      surgery_id: rbs.Surgery.surgery_id,
+      name: rbs.Surgery.name
+    }))
+  };
+};
+
+// 기록장 수정
+exports.updateRecordBook = async (recordBookId, { title }) => {
+  const [updated] = await RecordBook.update(
+    { title },
+    { where: { record_book_id: recordBookId } }
+  );
+  if (!updated) throw new Error('수정할 기록장이 없습니다.');
+  return {
+    record_book_id: Number(recordBookId),
+    title,
+    updated_at: new Date().toISOString()
+  };
+};
+
+// 기록장 삭제
+exports.deleteRecordBook = async (recordBookId) => {
+  await RecordBook.destroy({ where: { record_book_id: recordBookId } });
+};

--- a/services/recordEntryService.js
+++ b/services/recordEntryService.js
@@ -1,0 +1,81 @@
+const { RecordEntry, RecordImage } = require('../models');
+
+
+// 회복 기록 생성
+exports.createRecordEntry = async (recordBookId, { date, symptom, diary, images }) => {
+  const entry = await RecordEntry.create({
+    record_book_id: recordBookId,
+    date,
+    symptom,
+    diary,
+  });
+
+  if (images && images.length > 0) {
+    const imageRecords = images.map(url => ({
+      entry_id: entry.entry_id,
+      image_url: url,
+    }));
+    await RecordImage.bulkCreate(imageRecords);
+  }
+
+  return { entry_id: entry.entry_id, date: entry.date };
+};
+
+// 회복 기록 목록 조회
+exports.getRecordEntries = async (recordBookId, { date, page = 1, limit = 10, sort = 'desc' }) => {
+  const where = { record_book_id: recordBookId };
+  if (date) where.date = date;
+
+  const offset = (page - 1) * limit;
+  const { rows, count } = await RecordEntry.findAndCountAll({
+    where,
+    order: [['date', sort]],
+    offset,
+    limit: parseInt(limit),
+    include: [{ model: RecordImage, as: 'images' }],
+  });
+
+  return {
+    entries: rows,
+    pagination: { total: count, page, limit }
+  };
+};
+
+// 회복 기록 상세
+exports.getRecordEntryDetail = async (entryId) => {
+  const entry = await RecordEntry.findByPk(entryId, {
+    include: [{ model: RecordImage, as: 'images' }]
+  });
+  return entry;
+};
+
+
+// 회복 기록 수정
+exports.updateRecordEntry = async (entryId, { symptom, diary, images }) => {
+  const entry = await RecordEntry.findByPk(entryId);
+  if (!entry) throw new Error('Entry not found');
+
+  await entry.update({ symptom, diary, updated_at: new Date() });
+
+  if (images) {
+    await RecordImage.destroy({ where: { entry_id: entryId } });
+    if (images.length > 0) {
+      const imageRecords = images.map(url => ({
+        entry_id: entryId,
+        image_url: url,
+      }));
+      await RecordImage.bulkCreate(imageRecords);
+    }
+  }
+
+  return { entry_id: entry.entry_id, updated_at: entry.updated_at };
+};
+
+
+// 회복 기록 삭제
+exports.deleteRecordEntry = async (entryId) => {
+  const entry = await RecordEntry.findByPk(entryId);
+  if (!entry) throw new Error('Entry not found');
+  await entry.update({ deleted_at: new Date() });
+  // 실제 삭제를 원하면: await entry.destroy();
+};

--- a/swagger/swagger.js
+++ b/swagger/swagger.js
@@ -1,0 +1,29 @@
+const swaggerJsdoc = require('swagger-jsdoc');
+
+const options = {
+  definition: {
+    openapi: '3.0.0',
+    info: {
+      title: 'SYNCE API 명세',
+      version: '1.0.0',
+      description: 'SYNCE 프로젝트의 RESTful API 문서입니다.',
+    },
+    servers: [
+      { url: 'http://localhost:3000', description: '로컬 개발 서버' },
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+    },
+  },
+  apis: ['./routes/*.js', './swagger/*'],
+};
+
+const specs = swaggerJsdoc(options);
+
+module.exports = { specs };


### PR DESCRIPTION
## 📝 PR 유형
어떤 변경 사항이 있나요? (해당하는 항목에 [x] 표시)
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 문서 수정
- [x] 리팩토링
- [ ] 테스트 추가/수정
- [x] 빌드 관련 변경
- [ ] 기타 (아래에 자세히 설명)

## ✨ 주요 변경 사항
- 기록장(RecordBook) CRUD API 구현
- 회복 기록(RecordEntry) 및 이미지(RecordImage) CRUD API 구현
   - 이미지 등록 및 조회, 회복 기록과 연동
- Model/Sevice/Controller 계층 분리 및 에러 처리
- Swagger 주석 추가로 API 문서화
- Postman 테스트용 더미 데이터 및 예시 응답 추가

## 🖼️ 스크린샷(선택)
![image](https://github.com/user-attachments/assets/16332caf-4bd7-4bc2-8350-255455f4dd60)

## 💬 기타 참고 사항
- 인증 미들웨어(verifyToken) 적용
- SwaggerUI 에서 API 문서 및 테스트 가능 
   - 테스트 토큰 필요 시 말씀해주세요!
